### PR TITLE
Replace Eos with Fiveam

### DIFF
--- a/cl-dsl.asd
+++ b/cl-dsl.asd
@@ -12,7 +12,7 @@
 (defsystem :cl-dsl-tests
   :description "Tests for CL-DSL."
   :licence "GPL"
-  :depends-on (:cl-dsl :eos)
+  :depends-on (:cl-dsl :fiveam)
   :components ((:file "tests")))
 
 (defmethod perform ((op test-op) (sys (eql (find-system :cl-dsl))))

--- a/tests.lisp
+++ b/tests.lisp
@@ -18,7 +18,7 @@
   (with-macrolets '(foo bar) body))
 
 (defpackage #:cl-dsl-tests
-  (:use #:cl #:cl-dsl-test-1 #:eos)
+  (:use #:cl #:cl-dsl-test-1 #:fiveam)
   (:export #:run-tests))
 
 (in-package cl-dsl-tests)
@@ -28,8 +28,8 @@
 
 (defun run-tests ()
   (let ((results (run 'dsl)))
-    (eos:explain! results)
-    (unless (eos:results-status results)
+    (fiveam:explain! results)
+    (unless (fiveam:results-status results)
       (error "Tests failed."))))
 
 (test simple-dsl


### PR DESCRIPTION
Eos has been deprecated in favor of Fiveam.