### PR TITLE
Follow ASDF3 guideline of a single primary system per .asd file

### DIFF
--- a/cl-dsl.asd
+++ b/cl-dsl.asd
@@ -1,21 +1,19 @@
 ;;;; cl-dsl.asd
 
-(asdf:defsystem #:cl-dsl
+(defsystem #:cl-dsl
   :serial t
   :version "0.1"
   :description "Easily define domain specific languages"
   :author "Alexander Popolitov <popolit@gmail.com>"
   :license "GPL"
   :components ((:file "package")
-               (:file "cl-dsl")))
+               (:file "cl-dsl"))
+  :in-order-to ((test-op (test-op #:cl-dsl/tests))))
 
-(defsystem :cl-dsl-tests
+(defsystem #:cl-dsl/tests
   :description "Tests for CL-DSL."
   :licence "GPL"
   :depends-on (:cl-dsl :eos)
-  :components ((:file "tests")))
-
-(defmethod perform ((op test-op) (sys (eql (find-system :cl-dsl))))
-  (load-system :cl-dsl-tests)
-  (funcall (intern "RUN-TESTS" :cl-dsl-tests)))
+  :components ((:file "tests"))
+  :perform (test-op (o c) (symbol-call :cl-dsl-tests :run-tests)))
 


### PR DESCRIPTION
ASDF3 recommends declaring a single primary system per `.asd` file (e.g., `FOO`), with other, optional subsystems being named with a slash (e.g., `FOO/BAR`). This ensures that `FOO/BAR` can be loaded without first having to manually load `FOO`, as would be the case with e.g. `FOO-BAR` (ASDF would look for it in a non-existent `foo-bar.asd`).

See: [info asdf find-system](https://asdf.common-lisp.dev/asdf.html#Components-1)
